### PR TITLE
Margo-based implementation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,8 +39,18 @@ endif ()
 set (CMAKE_PREFIX_PATH "" CACHE STRING "External dependencies path")
 set (BUILD_SHARED_LIBS "OFF" CACHE BOOL "Build a shared library")
 
+option (ENABLE_MARGO "Build with Margo support" OFF)
+
 # Find required packages
 find_package (mercury CONFIG REQUIRED)
+
+if (${ENABLE_MARGO})
+  find_package (PkgConfig REQUIRED)
+  pkg_check_modules (margo REQUIRED IMPORTED_TARGET margo)
+  set (EXTRA_LIBS PkgConfig::margo)
+else ()
+  set (EXTRA_LIBS)
+endif ()
 
 add_subdirectory (src)
 add_subdirectory (tests)

--- a/include/mercury-progressor/mercury-progressor.h
+++ b/include/mercury-progressor/mercury-progressor.h
@@ -40,6 +40,8 @@
 
 typedef struct progressor_handle progressor_handle_t;
 
+typedef struct margo_instance* margo_instance_id; /* avoid including margo.h if not present */
+
 /*
  * progressor_stats: run stats for a progressor and its handle.
  * note that the stats are zeroed each time the threads are started.
@@ -73,6 +75,22 @@ extern "C" {
  */
 progressor_handle_t *mercury_progressor_init(hg_class_t *hgclass,
                                              hg_context_t *hgcontext);
+
+/**
+ * mercury_progressor_init_from_margo: allocate and init a mercury
+ * progressor and return a handle to it.  The progressor will be
+ * created from a margo instance. Contrary to mercury_progressor_init,
+ * which does nto start the progress thread, the margo instance will
+ * already have a running progress thread.
+ *
+ * If mercury-progressor has not been built with Margo support,
+ * this function will fail and return NULL.
+ *
+ * @param mid margo instance to associate with the processor
+ *
+ * @return handle to progressor, or NULL (for allocation error)
+ */
+progressor_handle_t *mercury_progressor_init_from_margo(margo_instance_id mid);
 
 /*
  * mercury_progressor_get_progtimeout: get the current timeout setting
@@ -177,6 +195,19 @@ hg_class_t *mercury_progressor_hgclass(progressor_handle_t *hand);
  * @return the hgcontext
  */
 hg_context_t *mercury_progressor_hgcontext(progressor_handle_t *hand);
+
+/*
+ * mercury_progressor_hgclass: return margo_instance_id associated with
+ * the progressor our handle points to.  clients can safely cache
+ * the return value while the progressor is allocated.
+ *
+ * If mercury-progressor was not build with Margo support, this function
+ * will return NULL.
+ *
+ * @param hand the progressor handle of interest
+ * @return the margo_instance_id
+ */
+margo_instance_id mercury_progressor_mid(progressor_handle_t *hand);
 
 /*
  * mercury_progressor_addrstring: return pointer to a C string containing

--- a/spack.yaml
+++ b/spack.yaml
@@ -1,0 +1,20 @@
+# This spack.yaml file can be used to create a spack
+# environment for testing purpose. From inside This
+# directorty:
+#
+# ```
+# $ spack env create -d .
+# $ spack env activate .
+# $ spack install
+# ```
+spack:
+  specs:
+  - cmake
+  - mercury~boostsys ^libfabric fabrics=tcp,rxm
+  - mochi-margo@main
+  concretizer:
+    unify: true
+  modules:
+    prefix_inspections:
+      lib: [LD_LIBRARY_PATH]
+      lib64: [LD_LIBRARY_PATH]

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -40,14 +40,24 @@ set (MERCURY_PROGRESSOR_VERSION
 # create library target (user can specify shared vs. static using
 # BUILD_SHARED_LIBS).  arrange for users of our lib to get the correct "-I"'s
 #
-add_library (mercury-progressor mercury-progressor.c)
+if (${ENABLE_MARGO})
+  add_library (mercury-progressor margo-progressor.c)
+else ()
+  add_library (mercury-progressor mercury-progressor.c)
+endif ()
 target_include_directories (mercury-progressor
                             PUBLIC $<INSTALL_INTERFACE:include>)
+
+# configure config.h
+configure_file ("config.h.in" "config.h" @ONLY)
+# add the build directory as include path
+target_include_directories (mercury-progressor BEFORE PUBLIC
+                            $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>)
 
 # make sure our build includes are BEFORE a previously installed version
 target_include_directories (mercury-progressor BEFORE PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include/mercury-progressor>)
-target_link_libraries (mercury-progressor mercury)
+target_link_libraries (mercury-progressor mercury ${EXTRA_LIBS})
 # XXX: cmake 3.1 and newer define a Threads::Threads imported target
 # that we should switch too when we are ready to require 3.1 or better.
 # (3.1 was released late 2014)

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -1,0 +1,6 @@
+#ifndef _CONFIG_H
+#define _CONFIG_H
+
+#cmakedefine ENABLE_MARGO
+
+#endif

--- a/src/margo-progressor.c
+++ b/src/margo-progressor.c
@@ -1,0 +1,226 @@
+/*
+ * Copyright (c) 2019-2023, Carnegie Mellon University.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the University nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
+ * WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * margo-progressor.c  mercury progressor component implemented with margo
+ * 13-Jan-2023  mdorier@anl.gov
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include <margo.h>
+#include <margo-util.h>
+
+#include "mercury-progressor.h"
+
+struct margo_progressor {
+    margo_instance_id mid;
+    _Atomic unsigned  refcount;
+    int               owns_mid;
+    char              self_addr[128];
+};
+
+struct progressor_handle {
+    struct margo_progressor* pg;
+    _Atomic unsigned         needed;
+};
+
+/*
+ * API functions!
+ */
+
+progressor_handle_t *mercury_progressor_init_from_margo(margo_instance_id mid) {
+    if(!mid) return NULL;
+
+    hg_addr_t addr = HG_ADDR_NULL;
+    hg_return_t ret = margo_addr_self(mid, &addr);
+    if(ret != HG_SUCCESS) return NULL;
+    char self_addr[128];
+    hg_size_t addr_size = 128;
+    ret = margo_addr_to_string(mid, self_addr, &addr_size, addr);
+    if(ret != HG_SUCCESS) return NULL;
+
+    progressor_handle_t* pgh = calloc(1, sizeof(*pgh));
+    pgh->pg = calloc(1, sizeof(*(pgh->pg)));
+    pgh->pg->mid = mid;
+    pgh->pg->refcount = 1;
+    strcpy(pgh->pg->self_addr, self_addr);
+
+    return pgh;
+}
+
+margo_instance_id mercury_progressor_mid(progressor_handle_t *hand) {
+    if(!hand) return NULL;
+    return hand->pg->mid;
+}
+
+/*
+ * mercury_progressor_init: allocate and init progressor
+ */
+progressor_handle_t *mercury_progressor_init(hg_class_t *hgclass,
+                                             hg_context_t *hgcontext) {
+    struct margo_init_info init_info = {0};
+    init_info.hg_class = hgclass;
+    init_info.hg_context = hgcontext;
+    init_info.json_config = "{\"use_progress_thread\":true,\"rpc_thread_count\":1}";
+    margo_instance_id mid = margo_init_ext(
+            HG_Class_get_protocol(hgclass),
+            HG_Class_is_listening(hgclass),
+            &init_info);
+    if(!mid) return NULL;
+    progressor_handle_t* pgh = mercury_progressor_init_from_margo(mid);
+    if(!pgh) return NULL;
+    pgh->pg->owns_mid = 1;
+    return pgh;
+}
+
+/*
+ * mercury_progressor_get_progtimeout: get progtimeout (msec)
+ */
+unsigned int mercury_progressor_get_progtimeout(progressor_handle_t *hand) {
+    if(!hand) return 0;
+    unsigned int timeout = 0;
+    margo_get_progress_timeout_ub_msec(hand->pg->mid, &timeout);
+    return timeout;
+}
+
+/*
+ * mercury_progressor_set_progtimeout: set progtimeout (msec)
+ */
+void mercury_progressor_set_progtimeout(progressor_handle_t *hand,
+                                        unsigned int timeout) {
+    if(!hand) return;
+    margo_set_progress_timeout_ub_msec(hand->pg->mid, timeout);
+}
+
+/*
+ * mercury_progressor_duphandle: create a duplicate handle.
+ */
+progressor_handle_t *mercury_progressor_duphandle(progressor_handle_t *hand) {
+    if(!hand) return NULL;
+    progressor_handle_t* new_pgh = calloc(1, sizeof(*new_pgh));
+    new_pgh->pg = hand->pg;
+    new_pgh->pg->refcount++;
+    return new_pgh;
+}
+
+/*
+ * mercury_progressor_freehandle: free a progressor handle.   the
+ * caller should be holding the last reference to the handle.
+ */
+hg_return_t mercury_progressor_freehandle(progressor_handle_t *hand) {
+    if(!hand) return HG_SUCCESS;
+    if(--hand->pg->refcount == 0) {
+        if(hand->pg->owns_mid)
+            margo_finalize(hand->pg->mid);
+        free(hand->pg);
+    }
+    free(hand);
+    return HG_SUCCESS;
+}
+
+/*
+ * mercury_progressor_getstats: get stats from progress thread
+ */
+hg_return_t mercury_progressor_getstats(progressor_handle_t *hand,
+                                        struct progressor_stats *ps) {
+    if(!hand) return HG_INVALID_ARG;
+    if(!ps) return HG_SUCCESS;
+
+    margo_instance_id mid = hand->pg->mid;
+
+    memset(ps, 0, sizeof(*ps));
+    ps->is_running        = 1; /* margo is always running */
+    ps->needed            = hand->needed;
+    ps->progressor_refcnt = hand->pg->refcount;
+    ps->nprogress         = margo_get_num_progress_calls(mid);
+    ps->ntrigger          = margo_get_num_trigger_calls(mid);
+    // note: can't fill in runtime and runusage
+
+    return HG_SUCCESS;
+}
+
+/*
+ * mercury_progressor_nprogress: extract nprogress from progressor
+ */
+uint64_t mercury_progressor_nprogress(progressor_handle_t *hand) {
+    return hand ? margo_get_num_progress_calls(hand->pg->mid) : 0;
+}
+
+/*
+ * mercury_progressor_ntrigger: extract ntrigger from progressor
+ */
+uint64_t mercury_progressor_ntrigger(progressor_handle_t *hand) {
+    return hand ? margo_get_num_trigger_calls(hand->pg->mid) : 0;
+}
+
+/*
+ * mercury_progressor_hgclass: extract hg_class_t* from progressor
+ */
+hg_class_t *mercury_progressor_hgclass(progressor_handle_t *hand) {
+    return hand ? margo_get_class(hand->pg->mid) : NULL;
+}
+
+/*
+ * mercury_progressor_hgcontext: extract hg_context_t* from progressor
+ */
+hg_context_t *mercury_progressor_hgcontext(progressor_handle_t *hand) {
+    return hand ? margo_get_context(hand->pg->mid) : NULL;
+}
+
+/*
+ * mercury_progressor_addrstring: extract local address string.
+ * valid as long as handle is active, no need to free return value.
+ */
+char *mercury_progressor_addrstring(progressor_handle_t *hand) {
+    return hand ? hand->pg->self_addr : NULL;
+}
+
+/*
+ * mercury_progressor_needed: handle needs threads to be running
+ */
+hg_return_t mercury_progressor_needed(progressor_handle_t *hand) {
+    if(!hand) return HG_INVALID_ARG;
+    ++hand->needed;
+    return HG_SUCCESS;
+}
+
+/*
+ * mercury_progressor_idle: progressor handle no longer needs progressor
+ * service running.
+ */
+hg_return_t mercury_progressor_idle(progressor_handle_t *hand) {
+    if(!hand) return HG_INVALID_ARG;
+    --hand->needed;
+    return HG_SUCCESS;
+}

--- a/src/margo-progressor.c
+++ b/src/margo-progressor.c
@@ -69,6 +69,8 @@ progressor_handle_t *mercury_progressor_init_from_margo(margo_instance_id mid) {
     hg_size_t addr_size = 128;
     ret = margo_addr_to_string(mid, self_addr, &addr_size, addr);
     if(ret != HG_SUCCESS) return NULL;
+    ret = margo_addr_free(mid, addr);
+    if(ret != HG_SUCCESS) return NULL;
 
     progressor_handle_t* pgh = calloc(1, sizeof(*pgh));
     pgh->pg = calloc(1, sizeof(*(pgh->pg)));

--- a/src/mercury-progressor-config.cmake.in
+++ b/src/mercury-progressor-config.cmake.in
@@ -8,4 +8,11 @@ find_dependency(mercury)
 
 include ("${CMAKE_CURRENT_LIST_DIR}/mercury-progressor-targets.cmake")
 
+set (MERCURY_PROGRESSOR_USES_MARGO @ENABLE_MARGO@)
+
+if (MERCURY_PROGRESSOR_USES_MARGO)
+  find_dependency(PkgConfig)
+  pkg_check_modules (margo REQUIRED IMPORTED_TARGET margo)
+endif ()
+
 # could include a macros file if one is used

--- a/src/mercury-progressor.c
+++ b/src/mercury-progressor.c
@@ -435,6 +435,16 @@ static void load_stats(struct progressor_stats *ps, struct progressor *pg) {
  * API functions!
  */
 
+progressor_handle_t *mercury_progressor_init_from_margo(margo_instance_id mid) {
+    (void)mid;
+    return NULL;
+}
+
+margo_instance_id mercury_progressor_mid(progressor_handle_t *hand) {
+    (void)hand;
+    return NULL;
+}
+
 /*
  * mercury_progressor_init: allocate and init progressor
  */

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -12,6 +12,12 @@
 # 29-Oct-2019  chuck@ece.cmu.edu
 #
 
-add_executable(test-progressor test-progressor.c)
-target_link_libraries(test-progressor mercury-progressor)
-add_test(test-progressor test-progressor)
+if (${ENABLE_MARGO})
+  add_executable (test-margo-progressor test-margo-progressor.c)
+  target_link_libraries (test-margo-progressor mercury-progressor)
+  add_test (test-margo-progressor test-margo-progressor)
+endif ()
+
+add_executable (test-progressor test-progressor.c)
+target_link_libraries (test-progressor mercury-progressor)
+add_test (test-progressor test-progressor)

--- a/tests/test-progressor.c
+++ b/tests/test-progressor.c
@@ -65,17 +65,17 @@ void checkstat(char *tag, progressor_handle_t *p,
     }
 }
 
-MERCURY_GEN_PROC(sum_in_t,
+MERCURY_GEN_PROC(op_in_t,
         ((int32_t)(x))\
         ((int32_t)(y)))
 
-MERCURY_GEN_PROC(sum_out_t, ((int32_t)(ret)))
+MERCURY_GEN_PROC(op_out_t, ((int32_t)(ret)))
 
 hg_return_t sum(hg_handle_t handle)
 {
     hg_return_t ret;
-    sum_in_t in;
-    sum_out_t out;
+    op_in_t in;
+    op_out_t out;
 
     const struct hg_info* info = HG_Get_info(handle);
 
@@ -134,7 +134,7 @@ int main(int argc, char **argv) {
     printf("my address: %s\n", mercury_progressor_addrstring(phand));
 
     // register RPC
-    hg_id_t rpc_id = MERCURY_REGISTER(cls, "sum", sum_in_t, sum_out_t, sum);
+    hg_id_t sum_id = HG_Register_name(cls, "sum", hg_proc_op_in_t, hg_proc_op_out_t, sum);
 
     // get self address
     hg_addr_t self_addr = HG_ADDR_NULL;
@@ -146,14 +146,14 @@ int main(int argc, char **argv) {
 
     // create RPC handle
     hg_handle_t handle;
-    ret = HG_Create(ctx, self_addr, rpc_id, &handle);
+    ret = HG_Create(ctx, self_addr, sum_id, &handle);
     if (ret != HG_SUCCESS) {
         fprintf(stderr, "HG_Create failed (%d)\n", ret);
         exit(1);
     }
 
     // forward RPC
-    sum_in_t in;
+    op_in_t in;
     in.x = 42;
     in.y = 23;
     volatile int completed = 0;
@@ -167,7 +167,7 @@ int main(int argc, char **argv) {
     while(!completed) { usleep(100); }
 
     // get output
-    sum_out_t out;
+    op_out_t out;
     ret = HG_Get_output(handle, &out);
     if (ret != HG_SUCCESS) {
         fprintf(stderr, "HG_Get_output failed (%d)\n", ret);

--- a/tests/test-progressor.c
+++ b/tests/test-progressor.c
@@ -152,6 +152,9 @@ int main(int argc, char **argv) {
         exit(1);
     }
 
+    // make sure progress loop is runnning
+    mercury_progressor_needed(phand);
+
     // forward RPC
     op_in_t in;
     in.x = 42;
@@ -164,7 +167,7 @@ int main(int argc, char **argv) {
     }
 
     // ugly active loop
-    while(!completed) { usleep(100); }
+    while(!completed) { usleep(100);}
 
     // get output
     op_out_t out;
@@ -199,6 +202,9 @@ int main(int argc, char **argv) {
         fprintf(stderr, "HG_Addr_free failed (%d)\n", ret);
         exit(1);
     }
+
+    // stop the progress loop
+    mercury_progressor_idle(phand);
 
     checkstat("check 0", phand, &ps, 0, 0, 1);
 


### PR DESCRIPTION
This PR provides a margo-based implementation of the mercury-progressor. This implementation can be enabled by providing `-DENABLE_MARGO=ON` to cmake.

From an API perspective, existing codes can continue to use the exact same API. The use of Margo will simply change how the progress loop is managed internally. Enabling margo also provides two extra functions:
- `mercury_progressor_init_from_margo(margo_instance_id mid)` to initialize a progressor using an existing margo instances;
- `mercury_progressor_mid(progressor_handle_t*)` to get a margo instance from a progressor handle.

This PR also improves the existing test to add an RPC, and provides another test when margo is enabled, in which one RPC is done using Mercury and another is done concurrently using Margo, showing interoperability.

Contrary to the original implementation of the mercury progressor, the Margo-based implementation will keep the progress thread running all the time (the original implementation stopped the thread when it wasn't needed and respawned it when needed). This is something that could be fixed, if needed (we don't have a way right now to pause the progress loop in Margo, but we have an old PR with the feature, that was never merged and that we could revisit).